### PR TITLE
explicitly rendered json to remove spec error

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -13,6 +13,7 @@ class ConfirmationsController < ApplicationController
     if user.present?
       user.confirm!
       login user
+      render json: {message: "User confirmed and logged in successfully."}, status: :ok
     else
       render json: { error: "Invalid or expired token" }, status: :unprocessable_content
     end


### PR DESCRIPTION
This was done to remove the error in confirmations controller spec since we weren't rendering any json in confirmations controller due to which the tests were failing